### PR TITLE
Support Multiple Chatbot Providers

### DIFF
--- a/esthesis-core/templates/_helpers.tpl
+++ b/esthesis-core/templates/_helpers.tpl
@@ -178,12 +178,21 @@ spec:
               value: {{ .Values.chatbot.chatModel.provider | quote }}
             - name: QUARKUS_LANGCHAIN4J_EMBEDDING_MODEL_PROVIDER
               value: {{ .Values.chatbot.embeddingModel.provider | quote }}
+            - name: QUARKUS_LANGCHAIN4J_EASY_RAG_PATH
+              value: {{ .Values.chatbot.easyRag.path | quote }}
+            - name: QUARKUS_LANGCHAIN4J_EASY_RAG_PATH_TYPE
+              value: {{ .Values.chatbot.easyRag.pathType | quote }}
+
+              {{- if eq .Values.chatbot.chatModel.provider "openai" }}
             - name: QUARKUS_LANGCHAIN4J_OPENAI_API_KEY
               value: {{ .Values.chatbot.openai.apiKey | quote }}
             - name: QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_MODEL_NAME
               value: {{ .Values.chatbot.openai.chatModel.modelName | quote }}
             - name: QUARKUS_LANGCHAIN4J_OPENAI_CHAT_MODEL_TEMPERATURE
               value: "{{ .Values.chatbot.openai.chatModel.temperature }}"
+              {{- end }}
+
+              {{- if eq .Values.chatbot.chatModel.provider "ollama" }}
             - name: QUARKUS_LANGCHAIN4J_OLLAMA_BASE_URL
               value: {{ .Values.chatbot.ollama.baseUrl | quote }}
             - name: QUARKUS_LANGCHAIN4J_OLLAMA_CHAT_MODEL_MODEL_ID
@@ -194,9 +203,13 @@ spec:
               value: {{ .Values.chatbot.ollama.embeddingModel.modelId | quote }}
             - name: QUARKUS_LANGCHAIN4J_OLLAMA_EMBEDDING_MODEL_TEMPERATURE
               value: "{{ .Values.chatbot.ollama.embeddingModel.temperature }}"
-            - name: QUARKUS_LANGCHAIN4J_EASY_RAG_PATH
-              value: {{ .Values.chatbot.easyRag.path | quote }}
-            - name: QUARKUS_LANGCHAIN4J_EASY_RAG_PATH_TYPE
-              value: {{ .Values.chatbot.easyRag.pathType | quote }}
+              {{- end }}
             {{- end }}
 {{- end }}
+
+
+{{- define "chatbotImage" -}}
+{{- with .Values.chatbot.chatModel }}
+{{- printf "esthesis-core-srv-chatbot-%s" .provider -}}
+{{- end -}}
+{{- end -}}

--- a/esthesis-core/templates/srv-chatbot/deployment.yaml
+++ b/esthesis-core/templates/srv-chatbot/deployment.yaml
@@ -5,7 +5,7 @@
   "podLogging" true
   "podMaxCpu" "1"
   "podMaxMemory" "1G"
-  "podName" "esthesis-core-srv-chatbot"
+  "podName" (include "chatbotImage" .)
   "podProbes" true
   "podChatbot" true
   "registry" .Values.esthesisRegistry


### PR DESCRIPTION
Update templates to dynamically add environment variable due to chatmodel provider selected. Also deployment name and image used for chatbot include the  chatbot model provider.

Testing Steps:
Temporary change the values.prod.yml to enable chatbot and select a model provider ("ollama", "openai"). Then with a helm template commant we can see in template file on chatbot deployment the correct variables and image used.