### PR TITLE
New helm charts local setup test

### DIFF
--- a/esthesis-core-deps/templates/kafka/strimzi-kafkauser.yaml
+++ b/esthesis-core-deps/templates/kafka/strimzi-kafkauser.yaml
@@ -9,6 +9,11 @@ metadata:
 spec:
   authentication:
     type: {{ .auth | default "scram-sha-512" }}
+    password:
+      valueFrom:
+        secretKeyRef:
+          name: {{ .name }}
+          key: password
   {{- with .authorization }}
   authorization:
     type: simple

--- a/esthesis-core-deps/templates/service-aliases.yaml
+++ b/esthesis-core-deps/templates/service-aliases.yaml
@@ -1,0 +1,86 @@
+---
+# Service aliases to match local dev setup expectations
+# These aliases map the expected service names from the local dev setup to the actual services created by the Helm charts
+
+# Service alias: redis-master -> redis pods
+# The local dev setup expects redis-master.esthesis:6379
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+      name: redis
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+---
+# Service alias: mongodb-headless -> mongodb-rs0
+# The local dev setup expects mongodb-headless.esthesis:27017
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-headless
+  labels:
+    app: mongodb
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
+      name: mongodb
+  selector:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: mongodb
+    app.kubernetes.io/name: percona-server-mongodb
+---
+# Service alias: kafka -> kafka broker pods
+# The local dev setup expects kafka.esthesis:9092
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  labels:
+    app: kafka
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9092
+      targetPort: 9092
+      protocol: TCP
+      name: clients
+  selector:
+    strimzi.io/cluster: {{ .Values.kafka.name }}
+    strimzi.io/kind: Kafka
+    strimzi.io/name: {{ .Values.kafka.name }}-kafka
+---
+# Service alias: keycloak -> keycloak pods
+# The local dev setup expects keycloak.esthesis:80
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: keycloakx
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/esthesis-core-deps/values.yaml
+++ b/esthesis-core-deps/values.yaml
@@ -133,6 +133,7 @@ kafka:
   users:
     - name: esthesis-system
       auth: scram-sha-512
+      password: "esthesis-system"
 
 ##################################################################################################
 # Keycloak configuration (Codecentric KeycloakX)


### PR DESCRIPTION
Hello @AposLaz! 

To fully test the Dev Environment setup (https://esthes.is/docs/core/dev-environment-setup.html), I had to apply the changes in this PR, which essentially include:

1. Creating aliases for the services so they are available on the usual local URLs and ports in dev mode, such as:

- redis-master.esthesis:6379/0
- mosquitto.esthesis:1883
- mongodb-headless.esthesis:27017
- keycloak.esthesis
- kafka.esthesis:9092
- ...

2. Adding a default, but changeable, password/secret for Kafka: "esthesis-system".
I was encountering credential issues when running in dev mode without it.

Since the changes introduced by this PR may not be the final solution, the main goal here is to highlight that these two aspects are important for running everything locally in dev mode, if we want to avoid changing service scripts, which is also an option.



