### PR TITLE
feat(esthesis-core): make api resource requests configurable per service

### DIFF
--- a/esthesis-core/templates/_helpers.tpl
+++ b/esthesis-core/templates/_helpers.tpl
@@ -63,8 +63,8 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              cpu: "0.1"
-              memory: "128M"
+              cpu: {{ .podReqCpu | quote }}
+              memory: {{ .podReqMemory | quote }}
             limits:
               cpu: {{ .podMaxCpu | quote }}
               memory: {{ .podMaxMemory | quote }}

--- a/esthesis-core/templates/_helpers.tpl
+++ b/esthesis-core/templates/_helpers.tpl
@@ -63,8 +63,8 @@ spec:
           imagePullPolicy: Always
           resources:
             requests:
-              cpu: {{ .podReqCpu | quote }}
-              memory: {{ .podReqMemory | quote }}
+              cpu: {{ default "0.1" .podReqCpu | quote }}
+              memory: {{ default "128M" .podReqMemory | quote }}
             limits:
               cpu: {{ .podMaxCpu | quote }}
               memory: {{ .podMaxMemory | quote }}

--- a/esthesis-core/templates/srv-about/deployment.yaml
+++ b/esthesis-core/templates/srv-about/deployment.yaml
@@ -2,6 +2,8 @@
 {{ template "deployment.api.template" (merge (dict
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podName" "esthesis-core-srv-about"

--- a/esthesis-core/templates/srv-agent/deployment.yaml
+++ b/esthesis-core/templates/srv-agent/deployment.yaml
@@ -1,6 +1,8 @@
 {{ if not .Values.devMode }}
 {{ template "deployment.api.template" (merge (dict
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podName" "esthesis-core-srv-agent"

--- a/esthesis-core/templates/srv-application/deployment.yaml
+++ b/esthesis-core/templates/srv-application/deployment.yaml
@@ -2,6 +2,8 @@
 {{ template "deployment.api.template" (merge (dict
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-audit/deployment.yaml
+++ b/esthesis-core/templates/srv-audit/deployment.yaml
@@ -2,6 +2,8 @@
 {{ template "deployment.api.template" (merge (dict
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-campaign/deployment.yaml
+++ b/esthesis-core/templates/srv-campaign/deployment.yaml
@@ -3,6 +3,8 @@
   "podCamunda" true
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-chatbot/deployment.yaml
+++ b/esthesis-core/templates/srv-chatbot/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podOidcClient" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "1G"
   "podName" (include "chatbotImage" .)

--- a/esthesis-core/templates/srv-command/deployment.yaml
+++ b/esthesis-core/templates/srv-command/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-crypto/deployment.yaml
+++ b/esthesis-core/templates/srv-crypto/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "512M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-dashboard/deployment.yaml
+++ b/esthesis-core/templates/srv-dashboard/deployment.yaml
@@ -6,8 +6,10 @@
   "podKafka" true
   "podLogging" true
   "podRedis" true
+  "podReqCpu" "250m"
+  "podReqMemory" "256M"
   "podMaxCpu" "1"
-  "podMaxMemory" "256M"
+  "podMaxMemory" "512M"
   "podName" "esthesis-core-srv-dashboard"
   "podProbes" true
   "registry" .Values.esthesisRegistry

--- a/esthesis-core/templates/srv-dataflow/deployment.yaml
+++ b/esthesis-core/templates/srv-dataflow/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-device/deployment.yaml
+++ b/esthesis-core/templates/srv-device/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "512M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-dt/deployment.yaml
+++ b/esthesis-core/templates/srv-dt/deployment.yaml
@@ -1,6 +1,8 @@
 {{ if not .Values.devMode }}
 {{ template "deployment.api.template" (merge (dict
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podName" "esthesis-core-srv-dt"

--- a/esthesis-core/templates/srv-infrastructure/deployment.yaml
+++ b/esthesis-core/templates/srv-infrastructure/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-kubernetes/deployment.yaml
+++ b/esthesis-core/templates/srv-kubernetes/deployment.yaml
@@ -2,6 +2,8 @@
 {{ template "deployment.api.template" (merge (dict
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-provisioning/deployment.yaml
+++ b/esthesis-core/templates/srv-provisioning/deployment.yaml
@@ -2,6 +2,8 @@
 {{ template "deployment.api.template" (merge (dict
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-public-access/deployment.yaml
+++ b/esthesis-core/templates/srv-public-access/deployment.yaml
@@ -2,6 +2,8 @@
 {{ $redirectUrl := print "https://" .Values.esthesisHostname "/callback" }}
 {{ template "deployment.api.template" (merge (dict
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podName" "esthesis-core-srv-public-access"

--- a/esthesis-core/templates/srv-security/deployment.yaml
+++ b/esthesis-core/templates/srv-security/deployment.yaml
@@ -2,6 +2,8 @@
 {{ template "deployment.api.template" (merge (dict
   "podOidc" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "256M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-settings/deployment.yaml
+++ b/esthesis-core/templates/srv-settings/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "512M"
   "podMongoDb" true

--- a/esthesis-core/templates/srv-tag/deployment.yaml
+++ b/esthesis-core/templates/srv-tag/deployment.yaml
@@ -3,6 +3,8 @@
   "podOidc" true
   "podKafka" true
   "podLogging" true
+  "podReqCpu" "0.1"
+  "podReqMemory" "128M"
   "podMaxCpu" "1"
   "podMaxMemory" "512M"
   "podMongoDb" true


### PR DESCRIPTION
## Summary

This PR makes API deployment resource requests configurable per service in `deployment.api.template`.

Currently, resource limits are already configurable per service through `podMaxCpu` and `podMaxMemory`, but resource requests are hardcoded in the shared helper:

```yaml
requests:
  cpu: "0.1"
  memory: "128M"
```

## Changes

* Added `podReqCpu` and `podReqMemory` to `deployment.api.template`
* Updated API service deployments to pass request values per service
* Preserved the existing request values where applicable

## Why

Different services may have different baseline CPU and memory requirements. Making resource requests configurable per service allows better Kubernetes scheduling and keeps request configuration consistent with the existing per-service limit configuration.

## Testing

* Rendered the Helm templates locally
* Verified that generated deployments contain both configurable `resources.requests` and `resources.limits`
